### PR TITLE
Mac gui bug

### DIFF
--- a/src/main/java/UIServer.java
+++ b/src/main/java/UIServer.java
@@ -19,7 +19,7 @@ public class UIServer {
 
     public static void createAndShowGUI() {
         frame = new JDialog();
-        frame.setLocation(200, 0);
+        frame.setLocation(200, System.getProperty("os.name").toLowerCase().startsWith("mac") ? 25 : 0 );
         frame.setResizable(true);
         frame.setUndecorated(true);
         frame.setAlwaysOnTop(true);


### PR DESCRIPTION
If the operative system is mac then the initial "y" position must change because the barmenu in mac is in the top of the desktop.